### PR TITLE
setting correct path to weather url

### DIFF
--- a/lib/python/notebook/flight-predictor.ipynb
+++ b/lib/python/notebook/flight-predictor.ipynb
@@ -34,7 +34,7 @@
     "from numpy import array\n",
     "import numpy as np\n",
     "import math\n",
-    "!pip install https://github.com/ibm-cds-labs/pipes-connector-flightstats/raw/master/lib/python/flightPredict.zip\n",
+    "!pip install --user https://github.com/ibm-cds-labs/simple-data-pipe-connector-flightstats/raw/master/lib/python/flightPredict/dist/flightPredict-0.2.tar.gz\n",
     "import flightPredict\n",
     "flightPredict.sqlContext = sqlContext\n",
     "flightPredict.cloudantHost='XXXX'\n",

--- a/lib/python/notebook/flight-predictor.ipynb
+++ b/lib/python/notebook/flight-predictor.ipynb
@@ -308,7 +308,7 @@
     }
    ],
    "source": [
-    "trainingData = flightPredict.loadLabeledDataRDD(\"training\")\n",
+    "trainingData = flightPredict.loadLabeledDataRDD(\"training\", None)\n",
     "print(trainingData)"
    ]
   },

--- a/lib/python/notebook/flight-predictor.ipynb
+++ b/lib/python/notebook/flight-predictor.ipynb
@@ -189,8 +189,8 @@
     }
    ],
    "source": [
-    "cloudantdata = flightPredict.loadDataSet(\"flightstats_training_data_for_flight_delay_predictive_app_training_set\",\\\n",
-    "                                         \"training\")\n",
+    "trainingDbName = \"flightstats_flight_demo_full_api_training_set\"\n",
+    "cloudantdata = flightPredict.loadDataSet(trainingDbName,"training")\n",
     "cloudantdata.printSchema()\n",
     "cloudantdata.count()"
    ]

--- a/lib/weatherAccess.js
+++ b/lib/weatherAccess.js
@@ -44,7 +44,7 @@ function weatherAccess(){
 			return callback(null, observationsMap[airportInfo.fs] );
 		}
 		
-		var url = weatherService.url+"/api/weather/v2/observations/timeseries/24hour?units=m&geocode=" + 
+		var url = weatherService.credentials.url+"/api/weather/v2/observations/timeseries/24hour?units=m&geocode=" + 
 			encodeURIComponent(airportInfo.latitude.toFixed(2) + "," + airportInfo.longitude.toFixed(2)) +
 			"&language=en-US";
 		request.get(url, {"json":true},


### PR DESCRIPTION
In order to get the proper URL, need to add `credentials` to the weatherService object's path. 
